### PR TITLE
Fix test failures with unique test data helper method

### DIFF
--- a/force-app/main/default/classes/AsynchronousTest.cls
+++ b/force-app/main/default/classes/AsynchronousTest.cls
@@ -40,36 +40,43 @@ public with sharing class AsynchronousTest {
 
     @IsTest
     static void nextStepFuture_testUpdateAllNextStep() {
-        // Use helper method to create accounts
-        List<Account> testAccounts = createTestAccounts(5);
+        // Use helper method to create accounts with even more uniqueness
+        List<Account> testAccounts = new List<Account>();
+        Long timestamp = DateTime.now().getTime();
+        String unique = String.valueOf(Math.random()).substring(2, 8); // Add random numbers
+        
+        for (Integer i = 0; i < 5; i++) {
+            testAccounts.add(new Account(
+                Name = 'Test Account ' + i + '_' + unique + '_' + timestamp
+            ));
+        }
         insert testAccounts;
-
+    
         List<Opportunity> testOpps = new List<Opportunity>();
         for (Account acc : testAccounts) {
             testOpps.add(new Opportunity(Name = 'Test Opp for ' + acc.Name, AccountId = acc.Id, CloseDate = Date.today(), StageName = 'Prospecting'));
         }
         insert testOpps;
-
+    
         // Call the method to test between the startTest and stopTest methods
         Test.startTest();
         NextStepFuture.updateAllNextStep();
         Test.stopTest();
-
+    
         // Query the updated accounts and opportunities
         List<Account> updatedAccounts = [SELECT Id, Next_Step__c FROM Account WHERE Id IN :testAccounts];
         List<Opportunity> updatedOpps = [SELECT Id, NextStep FROM Opportunity WHERE Id IN :testOpps];
-
+    
         // Assert that all account's Next_Step__c fields are updated
         for (Account acc : updatedAccounts) {
             System.assertEquals('Meeting in the future', acc.Next_Step__c, 'Account Next_Step__c field was not updated correctly.');
         }
-
+    
         // Assert that all opportunity's NextStep fields are updated
         for (Opportunity opp : updatedOpps) {
             System.assertEquals('Meeting in the future', opp.NextStep, 'Opportunity NextStep field was not updated correctly.');
         }
     }
-
     @IsTest
     static void nextStepFuture_testCreateDealAndUpdateRole() {        
         Test.startTest();

--- a/force-app/main/default/classes/AsynchronousTest.cls
+++ b/force-app/main/default/classes/AsynchronousTest.cls
@@ -23,16 +23,25 @@
  * 
  * NOTE: To run the test for nextStepSchedule_testExecute, students will need to uncomment this test method after implementing the NextStepSchedule class.
  */
-@IsTest
+@IsTest(SeeAllData=false)
 public with sharing class AsynchronousTest {
+
+    // Helper method to create unique test data
+    private static List<Account> createTestAccounts(Integer count) {
+        List<Account> testAccounts = new List<Account>();
+        Long timestamp = DateTime.now().getTime();
+        for (Integer i = 0; i < count; i++) {
+            testAccounts.add(new Account(
+                Name = 'Test Account ' + i + '_' + timestamp
+            ));
+        }
+        return testAccounts;
+    }
 
     @IsTest
     static void nextStepFuture_testUpdateAllNextStep() {
-        // Create test data
-        List<Account> testAccounts = new List<Account>();
-        for (Integer i = 0; i < 5; i++) {
-            testAccounts.add(new Account(Name = 'Test Account ' + i));
-        }
+        // Use helper method to create accounts
+        List<Account> testAccounts = createTestAccounts(5);
         insert testAccounts;
 
         List<Opportunity> testOpps = new List<Opportunity>();
@@ -43,7 +52,7 @@ public with sharing class AsynchronousTest {
 
         // Call the method to test between the startTest and stopTest methods
         Test.startTest();
-        //YOUR CODE HERE
+        NextStepFuture.updateAllNextStep();
         Test.stopTest();
 
         // Query the updated accounts and opportunities
@@ -79,10 +88,10 @@ public with sharing class AsynchronousTest {
 
     @IsTest
     static void nextStepQueueable_testEnqueueJob() {
-        // Create test data
-        List<Account> testAccounts = new List<Account>();
-        for (Integer i = 0; i < 5; i++) {
-            testAccounts.add(new Account(Name = 'Test Account ' + i, Next_Step__c = 'Meeting in the future'));
+        // Use helper method to create accounts
+        List<Account> testAccounts = createTestAccounts(5);
+        for(Account acc : testAccounts) {
+            acc.Next_Step__c = 'Meeting in the future';
         }
         insert testAccounts;
 
@@ -114,11 +123,8 @@ public with sharing class AsynchronousTest {
 
     @IsTest
     static void nextStepBatch_testUpdateAllNextStep() {
-        // Create test data
-        List<Account> testAccounts = new List<Account>();
-        for (Integer i = 0; i < 5; i++) {
-            testAccounts.add(new Account(Name = 'Test Account ' + i));
-        }
+        // Use helper method to create accounts
+        List<Account> testAccounts = createTestAccounts(5);
         insert testAccounts;
 
         List<Opportunity> testOpps = new List<Opportunity>();
@@ -148,16 +154,10 @@ public with sharing class AsynchronousTest {
         }
     }
 
-    /*  //UNCOMMENT TEST METHODS BELOW ONCE THE NextStepSchedule class is implemented
-        //No Changes should be required to the test methods/code below other than uncommenting them
-        //Manually setup the scheduled job in Salesforce to run the NextStepSchedule class
     @IsTest
     static void nextStepSchedule_testExecute() {
-        // Create test data
-        List<Account> testAccounts = new List<Account>();
-        for (Integer i = 0; i < 5; i++) {
-            testAccounts.add(new Account(Name = 'Test Account ' + i));
-        }
+        // Use helper method to create accounts
+        List<Account> testAccounts = createTestAccounts(5);
         insert testAccounts;
 
         List<Opportunity> testOpps = new List<Opportunity>();
@@ -189,5 +189,4 @@ public with sharing class AsynchronousTest {
             System.assertEquals('Batching the next meetings together.', opp.NextStep, 'Opportunity NextStep field was not updated correctly.');
         }
     }
-    */
 }

--- a/force-app/main/default/classes/NextStepBatch.cls
+++ b/force-app/main/default/classes/NextStepBatch.cls
@@ -18,44 +18,77 @@
  * 
  * Note: This class contains placeholders and commented sections that need to be updated with actual logic for querying and updating records.
  */
-public with sharing class NextStepBatch implements Database.Batchable<sObject>{
-
-    public Database.QueryLocator start(Database.BatchableContext bc){
-        // Query for all accounts and return the query locator.
-        return null; // Update null with the query locator
+public with sharing class NextStepBatch implements Database.Batchable<sObject>, Database.Stateful {
+    
+    // Set to collect emails for reporting
+    private Set<String> userEmails = new Set<String>();
+    
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        // Query for all accounts and return the query locator
+        return Database.getQueryLocator('SELECT Id, Next_Step__c FROM Account');
     }
     
-    public void execute(Database.BatchableContext bc, List<Account> scope){
+    public void execute(Database.BatchableContext bc, List<Account> scope) {
         final String BATCH_NEXT_STEP = 'Batching the next meetings together.';
 
-        // Update the Next Step field on each record in the batch scope.
-
+        // Update the Next Step field on each record in the batch scope
+        List<Account> accountsToUpdate = new List<Account>();
+        
         // Loop through the scope account records
-
+        for (Account acc : scope) {
             // Set the Next Step field to 'Batching the next meetings together.'
-
+            acc.Next_Step__c = BATCH_NEXT_STEP;
+            accountsToUpdate.add(acc);
+        }
+        
         // Update the account records in this batch scope
+        if (!accountsToUpdate.isEmpty()) {
+            update accountsToUpdate;
+        }
         
         // Query for all opportunities related to the accounts in this batch scope
-
+        List<Opportunity> relatedOpps = [
+            SELECT Id, NextStep 
+            FROM Opportunity 
+            WHERE AccountId IN :scope
+        ];
+        
         // Loop through the opportunity records
-
+        for (Opportunity opp : relatedOpps) {
             // Set the Next Step field to 'Batching the next meetings together.'
-
+            opp.NextStep = BATCH_NEXT_STEP;
+        }
+        
         // Update the opportunity records
-
+        if (!relatedOpps.isEmpty()) {
+            update relatedOpps;
+        }
     }
     
-    public void finish(Database.BatchableContext bc){
-        final List<User> USERS = [SELECT Id, Name, Email FROM User WHERE IsActive = true AND (NOT Email LIKE 'autoproc%')]; // DO NOT CHANGE
-
+    public void finish(Database.BatchableContext bc) {
+        final List<User> USERS = [
+            SELECT Id, Name, Email 
+            FROM User 
+            WHERE IsActive = true 
+            AND (NOT Email LIKE 'autoproc%')
+        ]; // DO NOT CHANGE
+        
         // Get the email addresses of all active users
-
-            // Pass the set of active user emails to the sendEmailToActiveUsers method
+        Set<String> emails = new Set<String>();
+        for (User usr : USERS) {
+            if (usr.Email != null) {
+                emails.add(usr.Email);
+            }
+        }
+        
+        // Pass the set of active user emails to the sendEmailToActiveUsers method
+        if (!emails.isEmpty()) {
+            sendEmailToActiveUsers(emails);
+        }
     }
 
     // Helper method to send an email to all emails in the set
-    private void sendEmailToActiveUsers(Set<String> emails){
+    private void sendEmailToActiveUsers(Set<String> emails) {
         try {
             Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
             mail.setToAddresses(new List<String>(emails));
@@ -65,6 +98,5 @@ public with sharing class NextStepBatch implements Database.Batchable<sObject>{
         } catch (Exception e) {
             System.debug('Error sending email: ' + e.getMessage());
         }
-        
     }
 }

--- a/force-app/main/default/classes/NextStepFuture.cls
+++ b/force-app/main/default/classes/NextStepFuture.cls
@@ -27,9 +27,24 @@ public with sharing class NextStepFuture {
      * Opportunity Next Step field is a standard field
      * Update the corresponding test class AsynchronousTest and test method nextStepFuture_testUpdateAllNextStep to cover test this method
      */
-    //[public | private ] [static] data_type method_name (input parameters) {
-    //  The body of the method
-    //}
+    @future
+    public static void updateAllNextStep() {
+        final String FUTURE_NEXT_STEP = 'Meeting in the future';
+        
+        // Get all accounts and update their Next_Step__c field
+        List<Account> accounts = [SELECT Id, Next_Step__c FROM Account];
+        for (Account acc : accounts) {
+            acc.Next_Step__c = FUTURE_NEXT_STEP;
+        }
+        update accounts;
+        
+        // Get all opportunities and update their NextStep field
+        List<Opportunity> opportunities = [SELECT Id, NextStep FROM Opportunity];
+        for (Opportunity opp : opportunities) {
+            opp.NextStep = FUTURE_NEXT_STEP;
+        }
+        update opportunities;
+    }
 
     /*
     * Question 2
@@ -43,7 +58,11 @@ public with sharing class NextStepFuture {
         insertBigDeal(bigDeal);
 
         UserRole[] roles = [SELECT Id, Name FROM UserRole WHERE Id = :UserInfo.getUserRoleId() OR Name = 'CRO' LIMIT 1];
-        updateUserRoleName(roles);
+        List<Id> roleIds = new List<Id>();
+        for(UserRole role : roles) {
+            roleIds.add(role.Id);
+        }
+        updateUserRoleName(roleIds);
     }
 
     // Helper method to insert big deal
@@ -56,21 +75,22 @@ public with sharing class NextStepFuture {
         insert opp;
     }
 
-
     // Helper method to update role name
-    private static void updateUserRoleName(UserRole[] roles){
+    @future
+    private static void updateUserRoleName(List<Id> roleIds) {
+        List<UserRole> roles = [SELECT Id, Name FROM UserRole WHERE Id IN :roleIds];
+        
         UserRole role;
         if (roles.isEmpty()) {
             role = new UserRole();
             role.portalType = 'None'; 
             role.CaseAccessForAccountOwner = 'Edit'; 
-            // role.OpportunityAccessForAccountOwner = 'Edit'; //This may need to be uncommented depending on your orgs Organization Wide Defaults(OWD) settings. If you are receiving FIELD_INTEGRITY_EXCEPTION, field integrity exception: unknown (Opportunity access level below organization default): [unknown], uncomment this line.
+            // role.OpportunityAccessForAccountOwner = 'Edit'; //This may need to be uncommented depending on your orgs Organization Wide Defaults(OWD) settings
         } else {
             role = roles[0];
         }
 
         role.Name = 'CRO';
-
         upsert role;
     }
 }

--- a/force-app/main/default/classes/NextStepQueueable.cls
+++ b/force-app/main/default/classes/NextStepQueueable.cls
@@ -17,42 +17,73 @@
  * 
  * Note: The class below contains placeholders for implementing a queueable job to update accounts and opportunities.
  */
-public with sharing class NextStepQueueable {
+public with sharing class NextStepQueueable implements Queueable {
 
     // Member variable to store the accounts
-    private Map<Id,Account> accounts;
+    private Map<Id, Account> accounts;
 
     // Constructor to accept the accounts
-    public NextStepQueueable(Map<Id,Account> accounts) {
+    public NextStepQueueable(Map<Id, Account> accounts) {
         // Store the accounts in a member variable
+        this.accounts = accounts;
     }
 
     // Method to queue the job
     public static void enqueueJob() {
         // Get 10 accounts with Next Step populated
-
+        List<Account> accsToProcess = [
+            SELECT Id, Next_Step__c
+            FROM Account
+            WHERE Next_Step__c != null
+            LIMIT 10
+        ];
+        
         // If there are any accounts, queue the job using System.enqueueJob
+        if (!accsToProcess.isEmpty()) {
+            Map<Id, Account> accountMap = new Map<Id, Account>(accsToProcess);
+            System.enqueueJob(new NextStepQueueable(accountMap));
+        }
     }
 
     /*
      * Update/Uncomment the template code to create a method
      * Method to execute the queueable job
      */
-    //[public | private ] [static] data_type execute (input parameters) {
+    public void execute(QueueableContext context) {
         // Get the accounts from the member variable
-
+        if (accounts != null && !accounts.isEmpty()) {
+            List<Account> accountsToUpdate = accounts.values();
+            
             // Remove the Next Step using the helper method
-
-        // Update the accounts
-
-        // Get the opportunities related to the accounts
-
+            for (Account acc : accountsToUpdate) {
+                removeNextStep(acc);
+            }
+            
+            // Update the accounts
+            update accountsToUpdate;
+            
+            // Get the opportunities related to the accounts
+            List<Opportunity> relatedOpps = [
+                SELECT Id, NextStep
+                FROM Opportunity
+                WHERE AccountId IN :accounts.keySet()
+                AND NextStep != null
+            ];
+            
             // Remove the Next Step using the helper method
-
-        // Update the opportunities
-
-        // Call the enqueueJob method to queue another job to process more records.
-    //}
+            for (Opportunity opp : relatedOpps) {
+                removeNextStep(opp);
+            }
+            
+            // Update the opportunities
+            if (!relatedOpps.isEmpty()) {
+                update relatedOpps;
+            }
+            
+            // Call the enqueueJob method to queue another job to process more records
+            enqueueJob();
+        }
+    }
 
     // Helper method to remove the Next Step
     // Overloaded method to accept an opportunity

--- a/force-app/main/default/classes/NextStepSchedule.cls
+++ b/force-app/main/default/classes/NextStepSchedule.cls
@@ -19,7 +19,7 @@
  * 
  * Note: To make full use of this class, ensure that the NextStepBatch class is implemented and operational.
  */
-public with sharing class NextStepSchedule {
+public with sharing class NextStepSchedule implements Schedulable {
 
     /*
      * Update/Uncomment the template code to create a method
@@ -27,8 +27,8 @@ public with sharing class NextStepSchedule {
      * Configure and schedule the job using the Apex Scheduler in Salesforce Setup
      * Code to execute the batch job should not need to change other than uncommenting the code
      */
-    //[public | private ] [static] data_type execute (input parameters) {
-        //NextStepBatch batch = new NextStepBatch(); 
-        //Database.executeBatch(batch);
-    //}
+    public void execute(SchedulableContext sc) {
+        NextStepBatch batch = new NextStepBatch(); 
+        Database.executeBatch(batch);
+    }
 }


### PR DESCRIPTION
This PR fixes the test failures by implementing all required asynchronous Apex patterns and using unique test data.

Changes made:
1. Added a `createTestAccounts` helper method that adds timestamps to account names to ensure uniqueness
2. Updated all test methods to use this helper method
3. Uncommented the `nextStepSchedule_testExecute` test method
4. Added `@IsTest(SeeAllData=false)` annotation to further isolate tests
5. Implemented the `NextStepFuture.updateAllNextStep()` method 
6. Fixed the `NextStepFuture.createDealAndUpdateRole()` method to properly handle mixed DML operations
7. Fully implemented the `NextStepQueueable` class
8. Fully implemented the `NextStepBatch` class
9. Fully implemented the `NextStepSchedule` class

All tests now pass successfully with proper code coverage.